### PR TITLE
Fix GitHub Pages deployment config

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,16 @@ npm run dev
 ```
 
 The game picks a secret word each day. Use hints or give up if you're stuck. Game state is stored in your browser's local storage.
+
+## Deployment
+
+To deploy the site to GitHub Pages make sure to build the production files first.
+
+```bash
+npm run build
+```
+
+The generated `dist` folder can then be served from the repository's
+`gh-pages` branch or committed directly when using GitHub Pages. The Vite
+configuration sets `base` to `/Best-Guess/` so assets resolve correctly at
+`https://philrinaldi.github.io/Best-Guess/`.

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,5 +2,6 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
+  base: '/Best-Guess/',
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- set `base` in `vite.config.js`
- document how to build for GitHub Pages

## Testing
- `npm run build` *(fails: vite: not found)*